### PR TITLE
feat: Add customization of the rendered highlight through a custom CSS setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "tailwindcss-classname-highlight",
   "displayName": "Tailwind CSS ClassName Highlight",
   "type": "commonjs",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "description": "",
@@ -44,6 +44,12 @@
           "default": false,
           "title": "Enable Hover Provider",
           "description": "You may need to disable Hovers provided by Tailwind CSS IntelliSense."
+        },
+        "tailwindcss-classname-highlight.highlightCss": {
+          "type": "string",
+          "default": "border-bottom: 1px dashed;",
+          "title": "Highlight CSS",
+          "description": "Custom CSS to be applied to highlighted TailwindCSS classes"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "tailwindcss-classname-highlight",
   "displayName": "Tailwind CSS ClassName Highlight",
   "type": "commonjs",
-  "version": "0.6.10",
+  "version": "0.6.9",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "description": "",
@@ -45,11 +45,11 @@
           "title": "Enable Hover Provider",
           "description": "You may need to disable Hovers provided by Tailwind CSS IntelliSense."
         },
-        "tailwindcss-classname-highlight.highlightCss": {
+        "tailwindcss-classname-highlight.textDecoration": {
           "type": "string",
-          "default": "border-bottom: 1px dashed;",
-          "title": "Highlight CSS",
-          "description": "Custom CSS to be applied to highlighted TailwindCSS classes"
+          "default": "none; border-bottom: 1px dashed;",
+          "title": "Text Decoration",
+          "description": "Text Decoration to be applied to highlighted TailwindCSS classes"
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ const { activate, deactivate } = defineExtension(async () => {
   const decorationRange: Ref<vscode.Range[]> = ref([])
   useEditorDecorations(
     textEditor,
-    { textDecoration: `none; ${vscode.workspace.getConfiguration('tailwindcss-classname-highlight')['highlightCss']}` },
+    { textDecoration: vscode.workspace.getConfiguration('tailwindcss-classname-highlight')['textDecoration'] },
     decorationRange,
   )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ const { activate, deactivate } = defineExtension(async () => {
   const decorationRange: Ref<vscode.Range[]> = ref([])
   useEditorDecorations(
     textEditor,
-    { textDecoration: 'none; border-bottom: 1px dashed;' },
+    { textDecoration: `none; ${vscode.workspace.getConfiguration('tailwindcss-classname-highlight')['highlightCss']}` },
     decorationRange,
   )
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Add a setting to be able to customize what the highlight looks like in the editor

### Linked Issues


### Additional context

I'm personally testing with 

`"tailwindcss-classname-highlight.highlightCss": "color: #f59e0b;"`

in my settings.json as I prefer the coloring to the underlining
