### PR TITLE
fix: resolve tailwind from workspace

### DIFF
--- a/src/decoration-v3.ts
+++ b/src/decoration-v3.ts
@@ -4,7 +4,7 @@ import micromatch from 'micromatch'
 import { TailwindUtils } from 'tailwind-api-utils'
 import * as vscode from 'vscode'
 
-import { logger } from './state'
+import { logger, useWorkspaceFsPath } from './state'
 import { defaultIdeMatchInclude, hash } from './utils'
 
 const CHECK_CONTEXT_MESSAGE_PREFIX = 'Check context failed: '
@@ -87,7 +87,7 @@ interface Result {
 }
 
 export class DecorationV3 {
-  tailwindUtils: TailwindUtils = new TailwindUtils()
+  tailwindUtils: TailwindUtils
 
   resultCache = new Map<string, Result[]>()
 
@@ -95,6 +95,8 @@ export class DecorationV3 {
     private tailwindLibPath: string,
     private tailwindConfigPath: string,
   ) {
+    const workspaceFsPath = useWorkspaceFsPath()
+    this.tailwindUtils = new TailwindUtils({ paths: [workspaceFsPath.value] })
     try {
       this.updateTailwindContext()
     }

--- a/src/decoration-v4.ts
+++ b/src/decoration-v4.ts
@@ -17,7 +17,7 @@ interface NumberRange {
 }
 
 export class DecorationV4 {
-  tailwindUtils = new TailwindUtils()
+  tailwindUtils: TailwindUtils
   textContentHashCache = new Map<string, NumberRange[]>()
 
   ig: Ignore | undefined
@@ -25,7 +25,10 @@ export class DecorationV4 {
   constructor(
     private tailwindLibPath: string,
     private cssPath: string,
-  ) {}
+  ) {
+    const workspaceFsPath = useWorkspaceFsPath()
+    this.tailwindUtils = new TailwindUtils({ paths: [workspaceFsPath.value] })
+  }
 
   async updateTailwindContext() {
     const now = Date.now()


### PR DESCRIPTION
Description

- Problem: The extension resolves tailwindcss using `process.cwd()`. When VS Code isn’t launched from the project folder (e.g. opened from Start Menu and then the workspace is opened), activation fails with `Could not find tailwindcss`, so highlighting never starts.
- Fix: Initialize `TailwindUtils` with the active workspace path in both V3 and V4 decorators: `new TailwindUtils({ paths: [workspaceFsPath.value] })`.
- Impact: Ensures the extension always resolves tailwindcss from the current workspace and avoids activation failures.